### PR TITLE
Evan event ics download link

### DIFF
--- a/core/templates/core/index.html
+++ b/core/templates/core/index.html
@@ -22,6 +22,7 @@
     <h4>{{ event.name }}</h4>
     <p> {{event.starttime}}</p>
     <p>{{ event.description|safe }}</p>
+    <a href="{% url 'event_ics_download' event.id %}">Add to iCal</a>
   {% endfor %}
 {% endfor %}
 

--- a/core/urls.py
+++ b/core/urls.py
@@ -1,8 +1,9 @@
 from django.contrib import admin
 from django.urls import include, path
 
-from .views import index
+from .views import index, event_ics_download
 
 urlpatterns = [
     path("", index),
+    path('event/<int:event_id>/ics', event_ics_download, name="event_ics_download")
 ]

--- a/core/util.py
+++ b/core/util.py
@@ -3,7 +3,7 @@ from uuid import uuid4
 from .models import Event as ModelEvent
 from icalendar import Event as ICalEvent, Calendar
 
-def getICSDownloadLinkFromEvent(event: ModelEvent):
+def get_ics_string_from_event(event: ModelEvent):
     cal = Calendar()
     cal_event = ICalEvent()
     t = event.starttime
@@ -17,10 +17,5 @@ def getICSDownloadLinkFromEvent(event: ModelEvent):
     cal_event.add('DESCRIPTION', event.description)
     cal_event.add('LOCATION', event.venue.name)
     cal.add_component(cal_event)
-
-    # dir = tempfile.mkdtemp()
-    # f = open(os.path.join(dir, 'example.ics'), 'wb')
-    # f.write(cal.to_ical())
-    # f.close()
-    print(cal.to_ical().decode("utf-8"))
+    return cal.to_ical().decode("utf-8")
 

--- a/core/util.py
+++ b/core/util.py
@@ -1,5 +1,5 @@
+import datetime, tempfile, os
 from uuid import uuid4
-import datetime
 from .models import Event as ModelEvent
 from icalendar import Event as ICalEvent, Calendar
 
@@ -17,4 +17,10 @@ def getICSDownloadLinkFromEvent(event: ModelEvent):
     cal_event.add('DESCRIPTION', event.description)
     cal_event.add('LOCATION', event.venue.name)
     cal.add_component(cal_event)
-    cal.to_ical()
+
+    # dir = tempfile.mkdtemp()
+    # f = open(os.path.join(dir, 'example.ics'), 'wb')
+    # f.write(cal.to_ical())
+    # f.close()
+    print(cal.to_ical().decode("utf-8"))
+

--- a/core/util.py
+++ b/core/util.py
@@ -1,0 +1,20 @@
+from uuid import uuid4
+import datetime
+from .models import Event as ModelEvent
+from icalendar import Event as ICalEvent, Calendar
+
+def getICSDownloadLinkFromEvent(event: ModelEvent):
+    cal = Calendar()
+    cal_event = ICalEvent()
+    t = event.starttime
+    date_start = datetime.datetime(t.year, t.month, t.day, t.hour, t.minute, 0, tzinfo=t.tzinfo)
+    date_end = datetime.datetime(t.year, t.month, t.day, (t.hour + 1) % 24, t.minute, tzinfo=t.tzinfo)
+    cal_event.add('DTSTART', date_start)
+    cal_event.add('DTEND', date_end)
+    cal_event.add('CREATED', datetime.datetime.now())
+    cal_event.add('UID', uuid4())
+    cal_event.add('SUMMARY', event.name)
+    cal_event.add('DESCRIPTION', event.description)
+    cal_event.add('LOCATION', event.venue.name)
+    cal.add_component(cal_event)
+    cal.to_ical()

--- a/core/views.py
+++ b/core/views.py
@@ -1,11 +1,12 @@
 from collections import defaultdict
 
 from django.db.models.functions import TruncDay
-from django.shortcuts import render
+from django.http import HttpResponse
+from django.shortcuts import render, get_object_or_404
 
 from .models import Event, Venue
 
-from .util import getICSDownloadLinkFromEvent
+from .util import get_ics_string_from_event
 
 
 def index(request):
@@ -15,7 +16,6 @@ def index(request):
     grouped_events = defaultdict(list)
     for event in all_events:
         grouped_events[event.day].append(event)
-        getICSDownloadLinkFromEvent(event)
     all_venues = Venue.objects.all()
     return render(
         request,
@@ -27,3 +27,10 @@ def index(request):
             "all_venues": all_venues,
         },
     )
+
+def event_ics_download(request, event_id):
+    event = get_object_or_404(Event, pk=event_id)
+    response = HttpResponse(get_ics_string_from_event(event), content_type="text/calendar")
+    response['Content-Disposition'] = 'inline; filename=event.ics'
+    return response
+

--- a/core/views.py
+++ b/core/views.py
@@ -5,6 +5,8 @@ from django.shortcuts import render
 
 from .models import Event, Venue
 
+from .util import getICSDownloadLinkFromEvent
+
 
 def index(request):
     all_events = (
@@ -13,6 +15,7 @@ def index(request):
     grouped_events = defaultdict(list)
     for event in all_events:
         grouped_events[event.day].append(event)
+        getICSDownloadLinkFromEvent(event)
     all_venues = Venue.objects.all()
     return render(
         request,

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,7 @@ django-stubs-ext==4.2.2
 django-tinymce==3.6.1
 filelock==3.12.4
 gunicorn==21.2.0
+icalendar==5.0.10
 install==1.3.5
 isort==5.12.0
 lazy-object-proxy==1.9.0
@@ -26,7 +27,10 @@ psycopg2-binary==2.9.8
 pylint==2.17.5
 pylint-django==2.5.3
 pylint-plugin-utils==0.8.2
+python-dateutil==2.8.2
 python-dotenv==1.0.0
+pytz==2023.3.post1
+six==1.16.0
 sqlparse==0.4.4
 tomli==2.0.1
 tomlkit==0.12.1


### PR DESCRIPTION
resolves #34
Add a link to download an ics file (iCalendar) for each event. We can replace or move the link itself later. The real feature here is the url that generates an ics file for each event.