### PR TITLE
Past months archive pages

### DIFF
--- a/core/templates/core/event_month_archive.html
+++ b/core/templates/core/event_month_archive.html
@@ -1,0 +1,99 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>{{year}} {{month}} &middot; nyc noise</title>
+</head>
+<style>
+    body {
+      background-color: #d4d0c7;
+      font-family: "Open Sans", sans-serif;
+    }
+
+    #centered_content
+    {
+      max-width:42em; margin:15px auto;
+    }
+
+    div.event {
+      margin-bottom: 5px;
+    }
+
+    span.smallInfo {
+      font-size: 0.9em;
+    }
+
+    /* ignore first p, i.e. make it not a block level element */
+    .eventDescription, .eventDescription p:first-child {
+      display: inline;
+    }
+
+</style>
+<h1>{{ year }} {{month}}</h1>
+
+<div>
+    {% for date, events in events.items %}
+    <h4>{{ date|date:"M d (D)"|lower }}</h4>
+
+    {% if date in date_messages %}
+      {% for message in date_messages|get_item:date %}
+        <h4>{{ message }}</h4>
+      {% endfor %}
+    {% endif %}
+
+    {% for event in events %}
+      <div class='event'>
+        • {{ event.starttime|date:"gA"|lower }}:
+
+        {% if event.hyperlink %}
+          <a href="{{ event.hyperlink }}" target="_blank" style='font-weight:bold'>{{ event.name }}</a>
+        {% else %}
+          <span style="font-weight:bold">{{ event.name }}</span>
+        {% endif %}
+
+        {% if event.venue %}
+          @
+
+          {% if event.age_policy and event.venue.neighborhood_and_borough %}
+            {{ event.venue.name }} ({{ event.age_policy }}), {{ event.venue.neighborhood_and_borough }}
+          {% elif event.age_policy %}
+            {{ event.venue.name }} ({{ event.age_policy }})
+          {% elif event.venue.neighborhood_and_borough %}
+            {{ event.venue.name }}, {{ event.venue.neighborhood_and_borough }}
+          {% else %}
+            {{ event.venue.name }}
+          {% endif %}
+
+          {% if event.venue.accessibility_emoji or event.venue.accessibility_notes or event.venue.accessibility_link %}
+            <span class='smallInfo'>
+            //
+              {% if event.venue.accessibility_link %}<a href="{{ event.venue.accessibility_link }}" target="_blank">ACCESS</a>{% else %}ACCESS{% endif %}:
+              {% if event.venue.accessibility_emoji %}
+                {{ event.venue.accessibility_emoji }}
+              {% endif %}
+              {% if event.venue.accessibility_notes %}
+                {{ event.venue.accessibility_notes }}
+              {% endif %}
+            </span>
+          {% endif %}
+        {% else %}
+          Unknown venue
+        {% endif %}
+
+        {% if event.description %}
+          //
+          <div class='eventDescription'>{{ event.description | safe }}</div>
+        {% endif %}
+
+        {% if event.venue %}
+          //
+          <a href="{{ event.venue.google_maps_link }}" target="_blank" class='smallInfo'>MAP</a>      
+        {% endif %}
+      </div>
+    {% endfor %}
+  {% endfor %}
+</div>
+
+
+</html>

--- a/core/tests.py
+++ b/core/tests.py
@@ -1,0 +1,33 @@
+from django.test import TestCase
+from django.urls import reverse
+from .models import Event, Venue
+import datetime
+
+class ArchiveTestCase(TestCase):
+    def setUp(self):
+        venue = Venue.objects.create(
+            name="Recurse Center",
+            location="397 Bridge St, Brooklyn, NY 11201",
+            age_policy="18+",
+            neighborhood_and_borough="",
+            google_maps_link="https://maps.app.goo.gl/moRm2h2e7vkEmBmz8",
+            accessibility_emoji="",
+            accessibility_notes="",
+            accessibility_link="",
+        )
+        
+        Event.objects.create(
+            name="cool event",
+            venue=venue,
+            starttime ="2023-04-15T12:00:00Z",
+        )
+
+    def test_archive_works(self):
+        url = reverse('event_month_archive', args=(2023, 4))
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.context["year"], 2023)
+        self.assertEqual(response.context["month"], "April")
+        self.assertEqual(len(response.context["events"]), 1)
+        self.assertEqual(response.context["events"][datetime.date(2023, 4, 15)][0].name, "cool event")
+        self.assertEqual(response.context["events"][datetime.date(2023, 4, 15)][0].age_policy, "18+")

--- a/core/urls.py
+++ b/core/urls.py
@@ -6,5 +6,5 @@ from .views import index, event_ics_download, event_month_archive
 urlpatterns = [
     path("", index),
     path('event/<int:event_id>/ics', event_ics_download, name="event_ics_download"),
-    path("<int:year>-<int:month>", event_month_archive, name="event month archive"),
+    path("<int:year>-<int:month>", event_month_archive, name="event_month_archive"),
 ]

--- a/core/urls.py
+++ b/core/urls.py
@@ -1,9 +1,10 @@
 from django.contrib import admin
 from django.urls import include, path
 
-from .views import index, event_ics_download
+from .views import index, event_ics_download, event_month_archive
 
 urlpatterns = [
     path("", index),
-    path('event/<int:event_id>/ics', event_ics_download, name="event_ics_download")
+    path('event/<int:event_id>/ics', event_ics_download, name="event_ics_download"),
+    path("<int:year>-<int:month>", event_month_archive, name="event month archive"),
 ]

--- a/core/views.py
+++ b/core/views.py
@@ -1,3 +1,5 @@
+import calendar
+
 from collections import defaultdict
 from datetime import datetime, timedelta
 
@@ -84,3 +86,22 @@ def event_ics_download(request, event_id):
     )
     response["Content-Disposition"] = "inline; filename=event.ics"
     return response
+
+
+
+def event_month_archive(request, year, month):
+    all_events = Event.objects.filter(starttime__year = year, starttime__month = month).annotate(date=TruncDate("starttime"))
+
+    grouped_events = defaultdict(list)
+    for event in all_events:
+        grouped_events[event.date].append(event)
+
+    return render(
+        request, 
+        "core/event_month_archive.html", 
+        {
+            'events': dict(grouped_events), 
+            'year': year, 
+            'month': calendar.month_name[month]
+        }
+    )


### PR DESCRIPTION
This PR allows the user to access events in an archive by year and date, by following URLs such as:
localhost:8000/2023-04

The URLs are parsed as integers, so leading zeroes are acceptable. For example, localhost:8000/2023-04 and localhost:8000/00002023-4 will render the same page.

**Changes:**

- Creates event_month_archive view in core/views.py, which filters events by year and month, then grouping them by date so they can be displayed individually under each date.
- In core/templates/core, event_month_archive.html has been created and set to render event information. This page is very barebones
- In core/urls.py, we've added the year-month URL which links to the event_month_archive view.
- Created core/tests.py and added a basic automated test to create an event and render the event archive page, ensuring that the event has been properly added in.
