### PR TITLE
fixed encoding error for wordpress page import

### DIFF
--- a/core/management/commands/import_wordpress_pages.py
+++ b/core/management/commands/import_wordpress_pages.py
@@ -41,7 +41,7 @@ class Command(BaseCommand):
         file_to_wordpress_export_xml_file = options["file_to_wordpress_export_xml_file"]
 
         parser = etree.XMLParser(strip_cdata=False)
-        with open(file_to_wordpress_export_xml_file) as f:
+        with open(file_to_wordpress_export_xml_file, encoding="UTF-8") as f:
             content = f.read()
 
             # manually clean up gremlins


### PR DESCRIPTION
specifying encoding type after i ran into an error importing static pages from XML by running python manage.py import_wordpress_pages

I also noticed that running this command a second time produces errors due to duplicate static page entries in the DB.  Once we're ready I'll probably just delete the rows with the pages that already got added and run it again.