### PR TITLE
added go-to-top links for all dates

### DIFF
--- a/core/static/core/scss/core.scss
+++ b/core/static/core/scss/core.scss
@@ -41,6 +41,11 @@ p {
   text-align: center;
 }
 
+.goToTopLink {
+  margin-top: 15px;
+  text-align: center;
+}
+
 /*************************************/
 /** Event styles                    **/
 /*************************************/

--- a/core/templates/core/index.html
+++ b/core/templates/core/index.html
@@ -24,7 +24,8 @@
       {% for event in events %}
         {% include 'core/event.html' with event=event only %}
       {% endfor %}
-      [<a href="#" id="goToTopLink">go to top</a>]
+
+      <div class="goToTopLink">[<a href="#">go to top</a>]</div>
     </article>
   {% endfor %}
 {% endblock content %}

--- a/core/templates/core/index.html
+++ b/core/templates/core/index.html
@@ -24,6 +24,7 @@
       {% for event in events %}
         {% include 'core/event.html' with event=event only %}
       {% endfor %}
+      [<a href="#" id="goToTopLink">go to top</a>]
     </article>
   {% endfor %}
 {% endblock content %}


### PR DESCRIPTION
A tiny update to index.html, which adds a [go to top] link under every date.
This closes an item on the punchlist.

![go-to-top_link_on_index](https://github.com/gregsadetsky/nycnoise/assets/28712729/2ab47e92-5ce5-4ed6-a84b-4b7310a9ec2c)
