### PR TITLE
bullets before entries

### DIFF
--- a/core/templates/core/index.html
+++ b/core/templates/core/index.html
@@ -20,10 +20,11 @@
           <h4>{{ message }}</h4>
         {% endfor %}
       {% endif %}
-
+      <ul>
       {% for event in events %}
-        {% include 'core/event.html' with event=event only %}
+       <li>{% include 'core/event.html' with event=event only %}</li> 
       {% endfor %}
+    </ul>
     </article>
   {% endfor %}
 {% endblock content %}


### PR DESCRIPTION
changed index.html so that events are listed as an unordered list, ie. have bullet points in front of them. 

This closes a punchlist item when merged.

![bullets-before-entries](https://github.com/gregsadetsky/nycnoise/assets/28712729/ba75ca39-c0ea-4017-acac-00c2d809c54b)
