### PR TITLE
use Event/StaticPage .all_objects manager when doing prod db dump

### DIFF
--- a/core/management/commands/populate_data_from_prod.py
+++ b/core/management/commands/populate_data_from_prod.py
@@ -65,8 +65,8 @@ class Command(BaseCommand):
         # delete all local venues and all local events, import them from server json dump
 
         Venue.objects.all().delete()
-        Event.objects.all().delete()
-        StaticPage.objects.all().delete()
+        Event.all_objects.all().delete()
+        StaticPage.all_objects.all().delete()
 
         Venue.objects.bulk_create(
             Venue(**venue_data) for venue_data in server_data["venues"]

--- a/core/views/internal_db_dump.py
+++ b/core/views/internal_db_dump.py
@@ -41,8 +41,8 @@ def internal_db_dump(request):
     return JsonResponse(
         {
             "all_migration_names": list(all_migration_names),
-            "events": list(Event.objects.all().values()),
+            "events": list(Event.all_objects.all().values()),
             "venues": list(Venue.objects.all().values()),
-            "static_pages": list(StaticPage.objects.all().values()),
+            "static_pages": list(StaticPage.all_objects.all().values()),
         }
     )


### PR DESCRIPTION
I noticed this issue when I was trying to manually test the new event submission form by submitting on the live site and then looking for the submitted data in the DB dump