### PR TITLE
autocomplete venue selection for user-submitted events

### DIFF
--- a/core/static/core/scss/core.scss
+++ b/core/static/core/scss/core.scss
@@ -294,6 +294,7 @@ main .search {
     }
     div > input,
     select,
+    span.select2-container,
     textarea {
       flex: 2;
     }

--- a/core/templates/core/base.html
+++ b/core/templates/core/base.html
@@ -90,6 +90,7 @@
         }
       });
     </script>
+    {% block head %}{% endblock head %}
 </head>
 
 <body>

--- a/core/templates/core/event_form.html
+++ b/core/templates/core/event_form.html
@@ -1,5 +1,8 @@
 {% extends 'core/base.html' %}
 
+{% block head %}
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.7.1/jquery.min.js"></script>
+{% endblock head %}
 
 {% block content %}
 <div class="event-submission">
@@ -7,6 +10,7 @@
   <form action="{% url 'submit_event' %}" method="post">
     {% csrf_token %}
     {{ form }}
+    {{ form.media }}
     <input type="submit" value="submit :D" style="font-size:1.6rem">
 
     <div style="padding:10px;display:block;font-size:0.9rem">if there's rly <b>no link</b> to yr event, plz <a href="mailto:contact@nyc-noise.com"><b>email a flyer</b></a> w/ subject line "[DATE] FLYER" (e.g. "2/14/24 FLYER") & i'll link to that instead; ty!</div>

--- a/core/tests/test_user_submitted_event.py
+++ b/core/tests/test_user_submitted_event.py
@@ -179,7 +179,7 @@ class UserSubmittedEventTestCase(TestCase):
         open_venue.save()
         closed_venue.save()
 
-        response = self.client.get(self.endpoint)
+        response = self.client.get(reverse('venue-autocomplete'))
         self.assertContains(response, open_venue.name)
         self.assertNotContains(response, closed_venue.name)
 

--- a/core/urls.py
+++ b/core/urls.py
@@ -1,6 +1,7 @@
 from django.conf import settings
 from django.urls import include, path, re_path
 
+from .views.autocomplete import VenueAutocomplete
 from .views.email_subscribe import email_subscribe
 from .views.event_gcal import event_gcal_redirect
 from .views.event_ics_download import event_ics_download
@@ -23,6 +24,7 @@ urlpatterns = [
     path("event/<int:event_id>/ics", event_ics_download, name="event_ics_download"),
     path("email-subscribe", email_subscribe, name="email_subscribe"),
     path("internal-api/db", internal_db_dump, name="internal_db_dump"),
+    path("venue-autocomplete/", VenueAutocomplete.as_view(), name='venue-autocomplete'),
 ]
 
 if settings.DEBUG and settings.SHOW_DEBUG_TOOLBAR:

--- a/core/views/autocomplete.py
+++ b/core/views/autocomplete.py
@@ -1,0 +1,13 @@
+from dal import autocomplete
+
+from core.models import Venue
+
+
+class VenueAutocomplete(autocomplete.Select2QuerySetView):
+    def get_queryset(self):
+        qs = Venue.objects.filter(is_open=True)
+
+        if self.q:
+            qs = qs.filter(name__icontains=self.q)
+
+        return qs

--- a/core/views/event_submission.py
+++ b/core/views/event_submission.py
@@ -5,6 +5,8 @@ from django.core.exceptions import ValidationError
 from django.utils.html import escape, mark_safe
 from django.views.generic.edit import CreateView
 
+from dal import autocomplete
+
 
 class DateTimePickerInput(forms.DateTimeInput):
     input_type = "datetime-local"
@@ -24,6 +26,7 @@ class UserSubmittedEventForm(forms.ModelForm):
         label="venue",
         queryset=Venue.objects.filter(is_open=True),
         required=False,
+        widget=autocomplete.ModelSelect2(url='venue-autocomplete/')
     )
     # description = forms.CharField()
     # description = forms.Textarea(rows=4)

--- a/nycnoise/settings/base.py
+++ b/nycnoise/settings/base.py
@@ -24,6 +24,8 @@ ALLOWED_HOSTS = os.environ["ALLOWED_HOSTS"].split(",")
 # Application definition
 
 INSTALLED_APPS = [
+    'dal',
+    'dal_select2',
     "django.contrib.admin",
     "django.contrib.auth",
     "django.contrib.contenttypes",

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ dj-database-url==2.1.0
 Django==4.2.10
 django-admin-sortable2==2.1.10
 django-appconf==1.0.6
+django-autocomplete-light==3.11.0
 django-compressor==4.4
 django-debug-toolbar==4.3.0
 django-js-asset==2.2.0
@@ -24,7 +25,6 @@ gunicorn==21.2.0
 icalendar==5.0.11
 idna==3.6
 iniconfig==2.0.0
-install==1.3.5
 isort==5.13.2
 lazy-object-proxy==1.10.0
 libsass==0.23.0


### PR DESCRIPTION
add venue autocomplete functionality using https://django-autocomplete-light.readthedocs.io/en/master/

this adds a dependency to jquery but it will only load for the event-submission page

![acl](https://github.com/user-attachments/assets/bdbe5982-e3c9-4859-8cb6-25e0fd05a207)
