### PR TITLE
submission form: remove venue override field form, reword extra info

### DIFF
--- a/core/tests/test_user_submitted_event.py
+++ b/core/tests/test_user_submitted_event.py
@@ -110,25 +110,13 @@ class UserSubmittedEventTestCase(TestCase):
         assert not form.is_valid()
 
     def test_user_must_include_venue(self):
-        """user must include venue info in either venue or venue_override
-        field"""
+        """user must include venue in submission"""
         form = UserSubmittedEventForm(
             dict(
                 starttime=timezone.now(),
                 title="brutal prog matinée",
                 artists="grand ulena",
                 venue=self.venue,
-            )
-        )
-        assert form.is_valid(), form.errors
-        form.save()
-
-        form = UserSubmittedEventForm(
-            dict(
-                starttime=timezone.now(),
-                title="brutal prog matinée",
-                artists="grand ulena",
-                venue_override="not sure yet",
             )
         )
         assert form.is_valid(), form.errors

--- a/core/views/autocomplete.py
+++ b/core/views/autocomplete.py
@@ -1,13 +1,38 @@
+from core.models import Venue
 from dal import autocomplete
 
-from core.models import Venue
+
+def parse_venue_name(q):
+    """
+    Parse a venue name string that might have 'the' prefix.
+
+    Args:
+        q (str): Venue name string, possibly with 'the ' prefix
+
+    Returns:
+        tuple: (name, name_the) where:
+            - name (str): The venue name without 'the' prefix if it existed
+            - name_the (bool): Whether the original string had 'the' prefix
+    """
+    q = q.strip()
+
+    # Check if query starts with 'the ' (case insensitive)
+    if q.lower().startswith("the "):
+        name = q[4:].strip()  # Remove 'the ' prefix (4 characters)
+        return name, True
+    else:
+        return q, False
 
 
 class VenueAutocomplete(autocomplete.Select2QuerySetView):
     def get_queryset(self):
         qs = Venue.objects.filter(is_open=True)
 
-        if self.q:
-            qs = qs.filter(name__icontains=self.q)
+        if not self.q:
+            return qs
 
-        return qs
+        name, name_the = parse_venue_name(self.q)
+
+        if name_the:
+            return qs.filter(name__icontains=name, name_the=True)
+        return qs.filter(name__icontains=name)

--- a/core/views/event_submission.py
+++ b/core/views/event_submission.py
@@ -14,13 +14,6 @@ class DateTimePickerInput(forms.DateTimeInput):
 class UserSubmittedEventForm(forms.ModelForm):
     template_name = "core/event_form_fields.html"
 
-    venue_override = forms.CharField(
-        label=mark_safe("<small>(if missing) venue</small>"),
-        required=False,
-        help_text=mark_safe(
-            "<small><i>plz include 1) address (or contact email if private), 2) age policy, & 3) wheelchair access basics for entry & restrooms</i></small>"
-        ),
-    )
     venue = forms.models.ModelChoiceField(
         label="venue",
         queryset=Venue.objects.filter(is_open=True),
@@ -41,7 +34,6 @@ class UserSubmittedEventForm(forms.ModelForm):
             "title",
             "artists",
             "venue",
-            "venue_override",
             "price",
             "ticket_hyperlink",
             "description",
@@ -54,7 +46,7 @@ class UserSubmittedEventForm(forms.ModelForm):
             "ticket_hyperlink": "ticket link",
             "artists": "artists",
             "price": "price",
-            "description": "extra info (prolly won't include ¯\\_(ツ)_/¯)",
+            "description": "extra info (e.g., venue if not in drop-down)"
         }
         widgets = {
             "starttime": DateTimePickerInput(),
@@ -82,7 +74,8 @@ class UserSubmittedEventForm(forms.ModelForm):
             raise ValidationError("event must include title or artists")
 
         venue_override = data.get("venue_override")
-        if data.get("venue") is None and venue_override.strip() == "":
+        venue = data.get("venue")
+        if venue is None and (venue_override is None or venue_override.strip() == ""):
             raise ValidationError("event must contain some venue information")
 
 


### PR DESCRIPTION
this assumes the current practice of adding a placeholder venue object that represents "the venue I want to add is not already in your venue DB-- please check the description/extrainfo field to find the venue"