### PR TITLE
Initialize 'symbol-sort-key' to prevent fade on first click

### DIFF
--- a/core/templates/map/map.html
+++ b/core/templates/map/map.html
@@ -110,6 +110,13 @@
                     'text-offset': [0, 0.9],
                     'icon-allow-overlap': true,
                     'symbol-z-order': 'source',
+                    'symbol-sort-key': [
+                      'match',
+                      ['get', 'divId'],
+                      '', // initialize to not match anything
+                      1000, // sort key when id is the hovered feature id
+                      0 // default
+                    ],
                   },
                   'paint': {
                   }


### PR DESCRIPTION
Resolves #413


https://github.com/user-attachments/assets/04bc1177-f6be-4718-a11e-e45988762d77