### PR TITLE
Vertically align text in links (even with emoji)

### DIFF
--- a/core/static/core/scss/no_cal.scss
+++ b/core/static/core/scss/no_cal.scss
@@ -4,6 +4,7 @@
   padding-top: 1px;
   padding-bottom: 2px;
   display: flex;
+  align-items: baseline;
   background: #8b5b8b;
 
   a {


### PR DESCRIPTION
small fix #461 :-)

on my laptop Safari (width shrunk to show things closer together):
<img width="362" alt="Screenshot 2025-03-25 at 7 54 48 PM" src="https://github.com/user-attachments/assets/b9b95eb0-d9dc-4e80-8d2c-5654bfc8a473" />
