### PR TITLE
Apply body styling (bg color) on redirect page

### DIFF
--- a/core/templates/core/empty.html
+++ b/core/templates/core/empty.html
@@ -1,9 +1,11 @@
+{% load sass_tags %}
 {% load meta %}
 <!DOCTYPE html>
 <html>
 
 <head {% meta_namespaces %}>
     {% include "meta/meta.html" %}
+    <link href="{% sass_src 'scss/core.scss' %}" rel="stylesheet" type="text/css" />
 </head>
 <body>
     <p>Please wait, redirecting you shortly...</p>


### PR DESCRIPTION
Fix #472

Looks like this:
<img width="859" alt="Screenshot 2025-03-30 at 10 08 49 AM" src="https://github.com/user-attachments/assets/52f53c6c-29fa-4587-86ed-8d734accc29b" />
