### PR TITLE
Change map bounds based on day's points

### DIFF
--- a/core/templates/map/map.html
+++ b/core/templates/map/map.html
@@ -85,6 +85,19 @@
           style: "https://api.protomaps.com/styles/v4/light/en.json?key=744c0d83a2202e0c",
           maxPitch: 0,
         });
+        // fit bounds of all points
+        const bounds = new maplibregl.LngLatBounds();
+        features.forEach(feature => {
+          bounds.extend(feature.geometry.coordinates);
+        });
+        map.fitBounds(bounds, {
+          padding: {top: 25, bottom: 10}, // more room at top for marker height
+          animate: false,
+        });
+        if (map.getZoom() > 10) {
+          // choosing to not zoom in from a lower number to make sure all points are visible
+          map.setZoom(10);
+        }
         map.on('load', () => {
           map.loadImage(
             '/marker-blue.png'


### PR DESCRIPTION
Resolve #471

## Examples
Points closer together:
<img width="682" alt="Screenshot 2025-03-30 at 11 01 46 AM" src="https://github.com/user-attachments/assets/59cf9b59-b503-48ab-baa9-4dc2cb784382" />

Points farther apart:
<img width="682" alt="Screenshot 2025-03-30 at 11 01 05 AM" src="https://github.com/user-attachments/assets/043fb653-dce9-463c-b43d-8c9288a549f7" />